### PR TITLE
Configurable Strictness in XmlSuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 #Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step

--- a/build.gradle
+++ b/build.gradle
@@ -27,15 +27,23 @@ repositories {
 
 dependencies {
     compile "org.mockito:mockito-core:2.23.0"
-    compile "org.testng:testng:6.3.1"
+    compile "org.testng:testng:6.4"
     testCompile "org.assertj:assertj-core:2.9.0"
 }
 
 test {
     include "**/*Test.class"
+    exclude 'org/mockitousage/testng/LenientStubsTest.class'
     useTestNG()
     testLogging {
         exceptionFormat 'full'
         showCauses true
     }
 }
+
+task testLenientStubs(type: Test) {
+    useTestNG() {
+        suites 'src/test/resources/testng-lenient.xml'
+    }
+}
+test.finalizedBy testLenientStubs

--- a/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
+++ b/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
@@ -22,6 +22,9 @@ import static org.mockito.internal.util.reflection.Fields.annotatedBy;
 public class MockitoBeforeTestNGMethod {
 
     private final Map<Object, MockitoSession> sessions;
+    private Strictness strictness = Strictness.STRICT_STUBS;
+
+    private static final String STRICTNESS_KEY = "org.mockito.testng.strictness";
 
     public MockitoBeforeTestNGMethod(Map<Object, MockitoSession> sessions) {
         this.sessions = sessions;
@@ -50,9 +53,14 @@ public class MockitoBeforeTestNGMethod {
         if (alreadyInitialized(testInstance)) {
             return;
         }
+
+        String strictnessValue = testResult.getTestContext().getSuite().getXmlSuite().getParameter(STRICTNESS_KEY);
+        if (null != strictnessValue) {
+            strictness = Strictness.valueOf(strictnessValue);
+        }
         MockitoSession session = Mockito.mockitoSession()
                 .initMocks(testInstance)
-                .strictness(Strictness.STRICT_STUBS)
+                .strictness(strictness)
                 .startMocking();
 
         sessions.put(testInstance, session);

--- a/src/test/java/org/mockitousage/testng/LenientStubsTest.java
+++ b/src/test/java/org/mockitousage/testng/LenientStubsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.testng;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class LenientStubsTest {
+
+    @Mock List list;
+
+    @Test public void does_not_detect_potential_stubbing_problem() {
+        when(list.add("a")).thenReturn(true);
+
+        list.add("b");
+    }
+
+    @Test public void does_not_detect_unused_stubs() {
+        when(list.add("a")).thenReturn(true);
+    }
+}

--- a/src/test/resources/testng-lenient.xml
+++ b/src/test/resources/testng-lenient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="Lenient Stubs">
+  <parameter name="org.mockito.testng.strictness"  value="LENIENT"/>
+  <test name="lenientStubsTest">
+    <classes>
+      <class name="org.mockitousage.testng.LenientStubsTest"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
My reason for doing this is outlined [in this issue comment](https://github.com/mockito/mockito-testng/issues/1#issuecomment-489178219)

**git commit body**
parameter key is "org.mockito.testng.strictness"
- upgrade TestNG to minimum version (6.3.1 -> 6.4) required to get ISuite.getParameters from ITestResult
- separate test task for lenient strictness tests + hook up to test task
- not testing Strictness.WARN - can't test this properly because that requires an accessible MockitoLogger