### PR TITLE
change from oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 #Skipping install step to avoid having Travis run arbitrary './gradlew assemble' task
 # https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step


### PR DESCRIPTION
critical fix for broken TravisCI build as explained in https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/2