### PR TITLE
Fixes #10 Configurable Strictness in XmlSuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ See the test source code for examples.
 Can you contribute usage information for this section of README file?
 Please send us a pull request!
 
+**Setting Strictness**
+
+STRICT_STUBS is the default, but this can be overriden if a test class is not ready for that level.  The relevant constant is `org.mockito.testng.MockitoTestNGListener.STRICTNESS_LEVEL` with the value `org.mockito.testng.strictness`
+
+Set in testng.xml
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="strictness">
+  <parameter name="org.mockito.testng.strictness"  value="LENIENT"/>
+  <!-- etc. -->
+</suite>
+```
+
+Set in annotation
+```java
+@BeforeSuite // or any TestNG annotation that allows for ITestContext as parameter for that matter
+public void beforeSuite(ITestContext iTestContext) {
+  iTestContext.getSuite().getXmlSuite().setParameter(org.mockito.testng.MockitoTestNGListener.STRICTNESS_LEVEL, "LENIENT");
+}
+```
+
 ## Developing
 
 - open in IDEA to develop or run ```./gradlew idea``` and then open in IDEA

--- a/build.gradle
+++ b/build.gradle
@@ -27,15 +27,23 @@ repositories {
 
 dependencies {
     compile "org.mockito:mockito-core:2.23.0"
-    compile "org.testng:testng:6.3.1"
+    compile "org.testng:testng:6.4"
     testCompile "org.assertj:assertj-core:2.9.0"
 }
 
 test {
     include "**/*Test.class"
+    exclude 'org/mockitousage/testng/LenientStubsTest.class'
     useTestNG()
     testLogging {
         exceptionFormat 'full'
         showCauses true
     }
 }
+
+task testLenientStubs(type: Test) {
+    useTestNG() {
+        suites 'src/test/resources/testng-lenient.xml'
+    }
+}
+test.finalizedBy testLenientStubs

--- a/src/main/java/org/mockito/testng/MockitoTestNGListener.java
+++ b/src/main/java/org/mockito/testng/MockitoTestNGListener.java
@@ -63,6 +63,8 @@ public class MockitoTestNGListener implements IInvokedMethodListener {
     private final MockitoBeforeTestNGMethod beforeTest = new MockitoBeforeTestNGMethod(sessions);
     private final MockitoAfterTestNGMethod afterTest = new MockitoAfterTestNGMethod(sessions);
 
+    public static final String STRICTNESS_LEVEL = "org.mockito.testng.strictness";
+
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
         if (hasMockitoTestNGListenerInTestHierarchy(testResult.getTestClass().getRealClass())) {
             beforeTest.applyFor(method, testResult);

--- a/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
+++ b/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
@@ -22,6 +22,9 @@ import static org.mockito.internal.util.reflection.Fields.annotatedBy;
 public class MockitoBeforeTestNGMethod {
 
     private final Map<Object, MockitoSession> sessions;
+    private Strictness strictness = Strictness.STRICT_STUBS;
+
+    private static final String STRICTNESS_KEY = "org.mockito.testng.strictness";
 
     public MockitoBeforeTestNGMethod(Map<Object, MockitoSession> sessions) {
         this.sessions = sessions;
@@ -50,9 +53,14 @@ public class MockitoBeforeTestNGMethod {
         if (alreadyInitialized(testInstance)) {
             return;
         }
+
+        String strictnessValue = testResult.getTestContext().getSuite().getXmlSuite().getParameter(STRICTNESS_KEY);
+        if (null != strictnessValue) {
+            strictness = Strictness.valueOf(strictnessValue);
+        }
         MockitoSession session = Mockito.mockitoSession()
                 .initMocks(testInstance)
-                .strictness(Strictness.STRICT_STUBS)
+                .strictness(strictness)
                 .startMocking();
 
         sessions.put(testInstance, session);

--- a/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
+++ b/src/main/java/org/mockito/testng/internal/MockitoBeforeTestNGMethod.java
@@ -17,14 +17,13 @@ import org.testng.ITestResult;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.testng.MockitoTestNGListener.STRICTNESS_LEVEL;
 import static org.mockito.internal.util.reflection.Fields.annotatedBy;
 
 public class MockitoBeforeTestNGMethod {
 
     private final Map<Object, MockitoSession> sessions;
     private Strictness strictness = Strictness.STRICT_STUBS;
-
-    private static final String STRICTNESS_KEY = "org.mockito.testng.strictness";
 
     public MockitoBeforeTestNGMethod(Map<Object, MockitoSession> sessions) {
         this.sessions = sessions;
@@ -54,7 +53,7 @@ public class MockitoBeforeTestNGMethod {
             return;
         }
 
-        String strictnessValue = testResult.getTestContext().getSuite().getXmlSuite().getParameter(STRICTNESS_KEY);
+        String strictnessValue = testResult.getTestContext().getSuite().getXmlSuite().getParameter(STRICTNESS_LEVEL);
         if (null != strictnessValue) {
             strictness = Strictness.valueOf(strictnessValue);
         }

--- a/src/test/java/org/mockitousage/testng/LenientStubsTest.java
+++ b/src/test/java/org/mockitousage/testng/LenientStubsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.testng;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class LenientStubsTest {
+
+    @Mock List list;
+
+    @Test public void does_not_detect_potential_stubbing_problem() {
+        when(list.add("a")).thenReturn(true);
+
+        list.add("b");
+    }
+
+    @Test public void does_not_detect_unused_stubs() {
+        when(list.add("a")).thenReturn(true);
+    }
+}

--- a/src/test/resources/testng-lenient.xml
+++ b/src/test/resources/testng-lenient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="Lenient Stubs">
+  <parameter name="org.mockito.testng.strictness"  value="LENIENT"/>
+  <test name="lenientStubsTest">
+    <classes>
+      <class name="org.mockitousage.testng.LenientStubsTest"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
_Resubmission of PR #8 (which I can no longer reopen due to rebase and subsequent force push)._

**git commit message**
parameter key is "org.mockito.testng.strictness"
- upgrade TestNG to minimum version (6.3.1 -> 6.4) required to get ISuite.getParameters from ITestResult
- separate test task for lenient strictness tests + hook up to test task
- not testing Strictness.WARN - can't test this properly because that requires an accessible MockitoLogger