### PR TITLE
Migrate to new Shipkit libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
     tags-ignore:
       - v* # release tags are automatically generated after a successful CI build, no need to run CI against them
   pull_request:
@@ -68,36 +66,38 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - name: 3. Build on ${{ matrix.os }} with Java ${{ matrix.java }}
-      run: ./gradlew build idea
+      run: ./gradlew build bintrayUpload idea -PbintrayDryRun
 
   #
   # Release job, only for pushes to the main development branch
   #
 
-# will be activated / implemented after shipkit upgrade
+  release:
+    runs-on: ubuntu-latest
+    needs: [build, verify] # build job must pass before we can release
 
-#  release:
-#    runs-on: ubuntu-latest
-#    needs: [build, verify] # build job must pass before we can release
-#
-#    if: github.event_name == 'push'
-#        && github.ref == 'refs/heads/release/3.x'
-#        && !contains(toJSON(github.event.commits.*.message), '[skip release]')
-#
-#    steps:
-#
-#    - name: Check out code
-#      uses: actions/checkout@v2 # https://github.com/actions/checkout
-#      with:
-#        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
-#
-#    - name: Set up Java 8
-#      uses: actions/setup-java@v1
-#      with:
-#        java-version: 8
-#
-#    - name: Build and publish
-#      run: ./gradlew bintrayUpload githubRelease --scan
-#      env:
-#        GH_WRITE_TOKEN: ${{secrets.GH_WRITE_TOKEN}}
-#        BINTRAY_API_KEY: ${{secrets.BINTRAY_API_KEY}}
+    if: github.event_name == 'push'
+        && github.ref == 'refs/heads/master'
+        && github.repository == 'mockito/mockito-testng'
+        && !contains(toJSON(github.event.commits.*.message), '[skip release]')
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v2 # https://github.com/actions/checkout
+      with:
+        fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
+
+    - name: Set up Java 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Build and publish to Bintray/MavenCentral
+      run: ./gradlew bintrayUpload githubRelease
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        BINTRAY_API_KEY: ${{secrets.BINTRAY_API_KEY}}
+        NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
+        NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
+

--- a/build.gradle
+++ b/build.gradle
@@ -5,15 +5,19 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:2.0.31"
+        classpath "org.shipkit:shipkit-auto-version:0.0.+"
+        classpath "org.shipkit:shipkit-changelog:0.0.+"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
     }
 }
 
 description = "Mockito for TestNG"
 
 apply plugin: "java-library"
-apply plugin: "idea"
-apply plugin: "org.shipkit.java"
+
+apply from: "gradle/shipkit.gradle"
+apply from: "gradle/java-publication.gradle"
+apply from: "gradle/ide.gradle"
 
 group = "org.mockito"
 

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -1,0 +1,7 @@
+assert rootProject == project
+
+allprojects {
+    apply plugin: 'idea'
+}
+
+idea.project.vcs = 'Git'

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -1,0 +1,121 @@
+//Sources/javadoc artifacts required by Maven module publications
+def licenseSpec = copySpec {
+    from project.rootDir
+    include "LICENSE"
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+    with licenseSpec
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set('javadoc')
+    from tasks.javadoc
+    with licenseSpec
+}
+
+jar {
+    with licenseSpec
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+//Gradle Maven publishing plugin configuration (https://docs.gradle.org/current/userguide/publishing_maven.html)
+apply plugin: "maven-publish"
+publishing {
+    publications {
+        javaLibrary(MavenPublication) { //name of the publication
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            artifactId = project.archivesBaseName
+
+            pom {
+                name = artifactId
+                description = project.description
+
+                url = "https://github.com/mockito/mockito-testng"
+                licenses {
+                    license {
+                        name = 'The MIT License'
+                        url = 'https://github.com/mockito/mockito-testng/blob/master/LICENSE'
+                        distribution = 'repo'
+                    }
+                }
+                developers {
+                    ['mockitoguy:Szczepan Faber',
+                     'mouyang:Matthew Ouyang',
+                     'skabashnyuk:Sergii Kabashniuk'].each { devData ->
+                        developer {
+                            def devInfo = devData.split(':')
+                            id = devInfo[0]
+                            name = devInfo[1]
+                            url = 'https://github.com/' + devInfo[0]
+                            roles = ["Core developer"]
+                        }
+                    }
+                }
+                scm {
+                    url = 'https://github.com/mockito/mockito-testng.git'
+                }
+                issueManagement {
+                    url = 'https://github.com/mockito/mockito-testng/issues'
+                    system = 'GitHub issues'
+                }
+                ciManagement {
+                    url = 'https://github.com/mockito/mockito-testng/actions'
+                    system = 'GH Actions'
+                }
+            }
+        }
+    }
+
+    //useful for testing - running "publish" will create artifacts/pom in a local dir
+    repositories { maven { url = "$buildDir/repo" } }
+}
+
+//fleshes out problems with Maven pom generation when building
+tasks.build.dependsOn("publishJavaLibraryPublicationToMavenLocal")
+
+//Bintray Gradle plugin configuration (https://github.com/bintray/gradle-bintray-plugin)
+//Plugin jars are added to the buildscript classpath in the root build.gradle file
+apply plugin: "com.jfrog.bintray"
+
+bintray {
+    //We need to use some user id here, because the Bintray key is associated with the user
+    //However, any user id is good, so longer the user has necessary privileges to the repository
+    user = 'szczepiq' //https://bintray.com/szczepiq
+    key = System.getenv('BINTRAY_API_KEY')
+    publish = true //can be changed to 'false' for testing
+    dryRun = project.hasProperty("bintrayDryRun")
+    publications = ['javaLibrary']
+
+    pkg {
+        repo = 'maven' //https://bintray.com/mockito/maven
+        userOrg = 'mockito' //https://bintray.com/mockito
+
+        name = "mockito-testng"
+
+        licenses = ['MIT']
+        labels = ['testng', 'mockito']
+        vcsUrl = "https://github.com/mockito/mockito-testng.git"
+
+        version {
+            name = project.version
+            vcsTag = "v$project.version"
+
+            //Notable versions are automatically synced to Maven Central repository (https://oss.sonatype.org/)
+            mavenCentralSync {
+                sync = true
+                user = System.getenv('NEXUS_TOKEN_USER')
+                password = System.getenv('NEXUS_TOKEN_PWD')
+            }
+        }
+    }
+}

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,47 +1,18 @@
-//
-//     https://github.com/mockito/shipkit/blob/master/docs/getting-started.md
-//
-shipkit {
-   gitHub.repository = "mockito/mockito-testng"
-   gitHub.readOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+//Plugin jars are added to the buildscript classpath in the root build.gradle file
+apply plugin: "org.shipkit.shipkit-auto-version"
+apply plugin: "org.shipkit.shipkit-changelog"
+apply plugin: "org.shipkit.shipkit-gh-release"
 
-   team.developers = [
-           'mockitoguy:Szczepan Faber',
-           'skabashnyuk:Sergii Kabashniuk'
-   ]
+tasks.named("generateChangelog") {
+    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    readOnlyToken = System.getenv("GITHUB_TOKEN")
+    repository = "mockito/mockito-testng"
 }
 
-allprojects {
-   plugins.withId("org.shipkit.bintray") {
-
-       //Bintray configuration is handled by JFrog Bintray Gradle Plugin
-       //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
-       bintray {
-
-           pkg {
-               repo = 'maven' //https://bintray.com/mockito/maven
-
-               //We need to use some user id here, because the Bintray key is associated with the user
-               //However, any user id is good, so longer the user has necessary privileges to the repository
-               user = 'szczepiq' //https://bintray.com/szczepiq
-
-               userOrg = 'mockito' //https://bintray.com/mockito
-               licenses = ['MIT']
-               labels = ['testng', 'mockito']
-               publish = true //can be changed to 'false' for testing
-
-               //See our Bintray packages at https://bintray.com/mockito/maven
-               name = "mockito-testng"
-
-               version {
-                   //Notable versions are automatically synced to Maven Central repository (https://oss.sonatype.org/)
-                   mavenCentralSync {
-                       sync = true
-                       user = System.env.NEXUS_TOKEN_USER
-                       password = System.env.NEXUS_TOKEN_PWD
-                   }
-               }
-           }
-       }
-   }
+tasks.named("githubRelease") {
+    def genTask = tasks.named("generateChangelog").get()
+    dependsOn genTask
+    repository = genTask.repository
+    changelog = genTask.outputFile
+    writeToken = System.getenv("GITHUB_TOKEN")
 }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,1 @@
-version=0.1.3
-previousVersion=0.1.2
+version=0.1.*


### PR DESCRIPTION
Based on code from mocito/mockito, witch change:
- sync to Central everything - removed condition for it
- use GITHUB_TOKEN for `readOnlyToken` and `writeToken` for shipkit
- github action will be run on every branch excluding `dependabot/**` - it take possibility to verify code on fork repo when prepare change in branch 

Before merge please provide secrets (if are defined in organization level - will be ok):
 - BINTRAY_API_KEY
 - NEXUS_TOKEN_USER
 - NEXUS_TOKEN_PWD

Testing locally by `./gradlew clean build bintrayUpload -PbintrayDryRun`, `./gradlew clean build publishToMavenLocal` `./gradlew clean build publish` last one create `build/repo` which can be examined

fix: #14 