### PR TITLE
Github Action and build improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
     tags-ignore:
       - v* # release tags are automatically generated after a successful CI build, no need to run CI against them
   pull_request:
@@ -22,6 +24,7 @@ jobs:
   #
   verify:
     runs-on:  ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
 
@@ -36,10 +39,8 @@ jobs:
       - name: 3. Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1 # https://github.com/gradle/wrapper-validation-action
 
-#      need change in build
-#
-#      - name: 4. Build and check reproducibility of artifacts
-#        run: ./check_reproducibility.sh
+      - name: 4. Build and check reproducibility of artifacts
+        run: ./check_reproducibility.sh
 
   #
   # Main build job

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Mockito utility classes for easy integration with TestNG
 
+[![CI](https://github.com/mockito/mockito-testng/workflows/CI/badge.svg)](https://github.com/mockito/mockito-testng/actions?query=workflow%3ACI)
+
 ## Installation
 
 ### Gradle
@@ -63,7 +65,7 @@ public class MyTest {
 ## Releasing
 
 Every merged pull request is published to JCenter and Maven Central.
-Actually, any change on master that happily builds on Travis CI is published
+Actually, any change on master that happily builds on GitHub Actions is published
 unless the binaries are the same as the previous release.
 The release automation uses Shipkit framework (http://shipkit.org).
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ public class MyTest {
 ## Releasing
 
 Every merged pull request is published to JCenter and Maven Central.
-Actually, any change on master that happily builds on GitHub Actions is published
+Actually, any change on master that happily builds on CI is published
 unless the binaries are the same as the previous release.
 The release automation uses Shipkit framework (http://shipkit.org).
 
 ## History
 
-The original TestNGListener was a part of the core Mockito repository. However, the jar was never released. Core Mockito team does not work with TestNG so it was hard for us to maintain TestNG integration. In Summer 2018 we moved the TestNG integration to a separate repository under "Mockito" organization on GitHub.
+The original TestNGListener was a part of the core Mockito repository. However, the jar was never released. Core Mockito team does not work with TestNG so it was hard for us to maintain TestNG integration. In Summer 2018 we moved the TestNG integration to a separate repository under "Mockito" organization.
 
 ## Help
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ description = "Mockito for TestNG"
 
 apply plugin: "java-library"
 
+apply from: "gradle/reproducible.gradle"
 apply from: "gradle/shipkit.gradle"
 apply from: "gradle/java-publication.gradle"
 apply from: "gradle/ide.gradle"

--- a/gradle/reproducible.gradle
+++ b/gradle/reproducible.gradle
@@ -1,0 +1,4 @@
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}


### PR DESCRIPTION
- add branch master to build on push - when we have only tags-ignore - build not run on other events
- support skip ci on verify job
- fix build reproducibility - I guess that this will be needed during release 
- add badge icon for GitHub Actions in README
- change Travis Ci to GitHUb Actions in README

some of change take account comments from last PR #19