### PR TITLE
Apply new Shipkit Changelog plugin properties

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -5,7 +5,7 @@ apply plugin: "org.shipkit.shipkit-gh-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-    readOnlyToken = System.getenv("GITHUB_TOKEN")
+    githubToken = System.getenv("GITHUB_TOKEN")
     repository = "mockito/mockito-testng"
 }
 
@@ -14,5 +14,6 @@ tasks.named("githubRelease") {
     dependsOn genTask
     repository = genTask.repository
     changelog = genTask.outputFile
-    writeToken = System.getenv("GITHUB_TOKEN")
+    githubToken = System.getenv("GITHUB_TOKEN")
+    newTagRevision = System.getenv("GITHUB_SHA")
 }


### PR DESCRIPTION
Configuration in _shipkit.gradle_ file can be updated with 2 new properties that were recently added to the plugin:
1. `newTagRevision` that ensures predictable tagging (adding this property fixes https://github.com/shipkit/shipkit-changelog/issues/46). _'GITHUB_SHA'_ that supplies the property, is an GH Action's env variable that exposes SHA of the commit that triggered the workflow.
2. Token that is set by `githubToken` property is used both to fetch and post via GH API. Earlier used _'readOnlyToken'_ and _'writeToken'_ properties are now deprecated.