### PR TITLE
Apply renamed plugin package

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,7 +1,7 @@
 //Plugin jars are added to the buildscript classpath in the root build.gradle file
 apply plugin: "org.shipkit.shipkit-auto-version"
 apply plugin: "org.shipkit.shipkit-changelog"
-apply plugin: "org.shipkit.shipkit-gh-release"
+apply plugin: "org.shipkit.shipkit-github-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'


### PR DESCRIPTION
Due to recent Github related naming convention applied to Shipkit Changelog plugin, the referenced _'org.shipkit.shipkit-gh-release'_ package should be changed for _'org.shipkit.shipkit-github-release'_.