### PR TITLE
Remove redundant dependency from CI's job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
   build:
     needs: [verify]
     runs-on:  ${{ matrix.os }}
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     # Definition of the build matrix
     strategy:
@@ -75,7 +74,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [build, verify] # build job must pass before we can release
+    needs: [build] # build job must pass before we can release
 
     if: github.event_name == 'push'
         && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Because _'build'_ job in CI workflow is dependent on _'verify'_, and _'build'_ is needed by _'release'_ job, _'verify'_ dependency is redundant in _'release'_ job and it can be removed.
Also checking against commit message containing _'[skip ci]'_ can be removed from _'build_' job - it is already checked in _'verify'_.