### PR TITLE
Issue20: Change not thread safe map implementations to concurrent ones

### DIFF
--- a/src/main/java/org/mockito/testng/MockitoTestNGListener.java
+++ b/src/main/java/org/mockito/testng/MockitoTestNGListener.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import org.mockito.InjectMocks;
@@ -82,8 +83,8 @@ import org.testng.annotations.Listeners;
  */
 public class MockitoTestNGListener implements IInvokedMethodListener {
 
-    private final Map<Object, MockitoSession> sessions = new HashMap<>();
-    private final Map<Object, Map<InstanceField, Object>> injectMocksFieldsValues = new HashMap<>();
+    private final Map<Object, MockitoSession> sessions = new ConcurrentHashMap<>();
+    private final Map<Object, Map<InstanceField, Object>> injectMocksFieldsValues = new ConcurrentHashMap<>();
 
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {

--- a/src/test/java/org/mockitousage/testng/ParallelMethodTest.java
+++ b/src/test/java/org/mockitousage/testng/ParallelMethodTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockitousage.testng;
+
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class ParallelMethodTest {
+
+    @Test(threadPoolSize = 4, invocationCount = 8)
+    public void testParallel() {
+        // nothing to do here, the execution just shouldn't fail
+    }
+
+}


### PR DESCRIPTION
My try to fix **ConcurrentModificationException**(s) when executing tests in parallel.